### PR TITLE
fixed undefined reference for timingStack.length

### DIFF
--- a/digest-hud.js
+++ b/digest-hud.js
@@ -219,7 +219,7 @@ angular.module('digestHud', [])
 
       function instrumentedPostDigest(fn) {
         // jshint validthis:true
-        if (timingStack.length) {
+        if (timingStack && timingStack.length) {
           fn = wrapExpression(fn, _.last(timingStack), 'overhead', true, true);
         }
         originalPostDigest.call(this, fn);


### PR DESCRIPTION
This should fix the error I get running digest-hud for my app:

```
TypeError: Cannot read property 'length' of undefined
    at Scope.instrumentedPostDigest [as $$postDigest] (http://localhost:3000/bower_components/angular-digest-hud/digest-hud.js:222:24)
    at runAnimationPostDigest (http://localhost:3000/bower_components/angular-animate/angular-animate.js:538:20)
    at Object.enter (http://localhost:3000/bower_components/angular-animate/angular-animate.js:958:18)
    at Object.enter (http://localhost:3000/bower_components/angular-ui-router/release/angular-ui-router.min.js:7:14016)
    at http://localhost:3000/bower_components/angular-ui-router/release/angular-ui-router.min.js:7:14584
    at publicLinkFn (http://localhost:3000/bower_components/angular/angular.js:6995:29)
    at j (http://localhost:3000/bower_components/angular-ui-router/release/angular-ui-router.min.js:7:14566)
    at http://localhost:3000/bower_components/angular-ui-router/release/angular-ui-router.min.js:7:14890
    at invokeLinkFn (http://localhost:3000/bower_components/angular/angular.js:8258:9)
    at nodeLinkFn (http://localhost:3000/bower_components/angular/angular.js:7768:11) <!-- uiView: header -->
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pkaminski/digest-hud/4)

<!-- Reviewable:end -->
